### PR TITLE
Fixes Space.ui.createEvents

### DIFF
--- a/source/helpers.coffee
+++ b/source/helpers.coffee
@@ -12,6 +12,7 @@ Space.ui.createEvents = (namespace, events) ->
     parent[key] = Space.messaging.Event.extend ->
       @type namespace + '.' + key
       @fields = fields
+      return this
 
 Space.ui.getEventTarget = (event) ->
   event.target.$blaze_range.view.templateInstance()


### PR DESCRIPTION
The return value was previously the fields instead of the instance.
Implicit CoffeeScript return values strike back :-)